### PR TITLE
corrige erro de valor numérico inválido ao listar todos os itens

### DIFF
--- a/sei/web/modulos/ia/md_ia_prompts_favoritos.php
+++ b/sei/web/modulos/ia/md_ia_prompts_favoritos.php
@@ -104,7 +104,7 @@ try {
         );
     }
 
-    if ($numIdMdIaGrupoPromptsFav > 0) {
+    if (is_numeric($numIdMdIaGrupoPromptsFav) && (int)$numIdMdIaGrupoPromptsFav > 0) {        
         $objMdIaPromptsFavoritosDTO->setNumIdMdIaGrupoPromptsFav($numIdMdIaGrupoPromptsFav);
     }
 


### PR DESCRIPTION
Corrige erro de valor númerico inválido.

Erro
Valor numérico inválido [Todos].


Trilha de Processamento:
0 /opt/infra/infra_php/InfraBD.php(1785): InfraOracle->formatarGravacaoNum()
1 /opt/infra/infra_php/InfraBD.php(1905): InfraBD->gravarCampo()
2 /opt/infra/infra_php/InfraBD.php(1354): InfraBD->adicionarBind()
3 /opt/infra/infra_php/InfraBD.php(1133): InfraBD->montarCondicao()
4 /opt/infra/infra_php/InfraBD.php(478): InfraBD->montarFromJoinWhere()
5 /opt/sei/web/modulos/ia/rn/MdIaPromptsFavoritosRN.php(177): InfraBD->listar()
6 /opt/infra/infra_php/InfraRN.php(154): MdIaPromptsFavoritosRN->listarConectado()
7 /opt/sei/web/modulos/ia/md_ia_prompts_favoritos.php(119): InfraRN->__call()
8 /opt/sei/web/modulos/ia/IaIntegracao.php(348): require_once('')
9 /opt/sei/web/SeiIntegracao.php(146): IaIntegracao->processarControlador()
10 /opt/sei/web/controlador.php(1926): SeiIntegracao->executar()
11 {main}
